### PR TITLE
Add config to serve challenge from the filesystem, removing the need to use a DB/ActiveRecord

### DIFF
--- a/app/controllers/letsencrypt_plugin/application_controller.rb
+++ b/app/controllers/letsencrypt_plugin/application_controller.rb
@@ -17,7 +17,7 @@ module LetsencryptPlugin
 
       def get_challenge_response
         if (CONFIG[:challenge_dir_name])
-          full_challenge_dir = File.join(Rails.root, CONFIG[:challenge_dir_name]);
+          full_challenge_dir = File.join(File.join(Rails.root, CONFIG[:challenge_dir_name], 'challenge');
           @response = { :response => IO.read(full_challenge_dir) }
         else
           @response = Challenge.first

--- a/app/controllers/letsencrypt_plugin/application_controller.rb
+++ b/app/controllers/letsencrypt_plugin/application_controller.rb
@@ -17,8 +17,7 @@ module LetsencryptPlugin
 
       def get_challenge_response
         if (CONFIG[:challenge_dir_name])
-          full_challenge_dir = File.join(File.join(Rails.root, CONFIG[:challenge_dir_name], 'challenge'))
-          @response = { :response => IO.read(full_challenge_dir) }
+          @response = Challenge.new
         else
           @response = Challenge.first
         end

--- a/app/controllers/letsencrypt_plugin/application_controller.rb
+++ b/app/controllers/letsencrypt_plugin/application_controller.rb
@@ -17,7 +17,7 @@ module LetsencryptPlugin
 
       def get_challenge_response
         if (CONFIG[:challenge_dir_name])
-          full_challenge_dir = File.join(File.join(Rails.root, CONFIG[:challenge_dir_name], 'challenge');
+          full_challenge_dir = File.join(File.join(Rails.root, CONFIG[:challenge_dir_name], 'challenge'))
           @response = { :response => IO.read(full_challenge_dir) }
         else
           @response = Challenge.first

--- a/app/controllers/letsencrypt_plugin/application_controller.rb
+++ b/app/controllers/letsencrypt_plugin/application_controller.rb
@@ -16,7 +16,12 @@ module LetsencryptPlugin
       end
 
       def get_challenge_response
-        @response = Challenge.first
+        if (CONFIG[:challenge_dir_name])
+          full_challenge_dir = File.join(Rails.root, CONFIG[:challenge_dir_name]);
+          @response = { :response => IO.read(full_challenge_dir) }
+        else
+          @response = Challenge.first
+        end
         challenge_failed('Challenge failed - Can not get response from database!') if @response.nil?
       end
 

--- a/app/models/letsencrypt_plugin/challenge.rb
+++ b/app/models/letsencrypt_plugin/challenge.rb
@@ -4,5 +4,14 @@ module LetsencryptPlugin
   if defined?(ActiveRecord::Base) == 'constant' && ActiveRecord::Base.class == Class 
     class Challenge < ActiveRecord::Base
     end
+  else
+    class Challenge
+      attr_accessor :response
+
+      def initialize
+        full_challenge_dir = File.join(Rails.root, CONFIG[:challenge_dir_name], 'challenge')
+        @response = IO.read(full_challenge_dir)
+      end
+    end
   end
 end

--- a/app/models/letsencrypt_plugin/challenge.rb
+++ b/app/models/letsencrypt_plugin/challenge.rb
@@ -1,4 +1,6 @@
 module LetsencryptPlugin
+  # if the project doesn't use ActiveRecord, we assume the challenge will
+  # be stored in the filesystem
   if defined?(ActiveRecord::Base) == 'constant' && ActiveRecord::Base.class == Class 
     class Challenge < ActiveRecord::Base
     end

--- a/app/models/letsencrypt_plugin/challenge.rb
+++ b/app/models/letsencrypt_plugin/challenge.rb
@@ -1,4 +1,6 @@
 module LetsencryptPlugin
-  class Challenge < ActiveRecord::Base
+  if defined?(ActiveRecord::Base) == 'constant' && ActiveRecord::Base.class == Class 
+    class Challenge < ActiveRecord::Base
+    end
   end
 end

--- a/lib/tasks/letsencrypt_plugin_tasks.rake
+++ b/lib/tasks/letsencrypt_plugin_tasks.rake
@@ -78,7 +78,7 @@ task :letsencrypt_plugin => :setup_logger do
 
   def create_csr
     Rails.logger.info("Creating CSR...")
-    Acme::CertificateRequest.new(names: [ CONFIG[:domain] ])
+    Acme::Client::CertificateRequest.new(names: [ CONFIG[:domain] ])
   end
   
   # Save the certificate and key

--- a/lib/tasks/letsencrypt_plugin_tasks.rake
+++ b/lib/tasks/letsencrypt_plugin_tasks.rake
@@ -59,8 +59,8 @@ task :letsencrypt_plugin => :setup_logger do
       end
     else # store in filesystem
       full_challenge_dir = File.join(Rails.root, CONFIG[:challenge_dir_name]);
-      if (!File.Directory?(full_challenge_dir))
-        File.MkDir(full_challenge_dir)
+      if (!File.directory?(full_challenge_dir))
+        Dir.mkdir(full_challenge_dir)
       end
       File.open(File.join(full_challenge_dir, 'challenge'), 'w') { |file| file.write(challenge) }
     end

--- a/lib/tasks/letsencrypt_plugin_tasks.rake
+++ b/lib/tasks/letsencrypt_plugin_tasks.rake
@@ -29,7 +29,7 @@ task :letsencrypt_plugin => :setup_logger do
 
     challenge.request_verification # => true
     
-    wait_for_status(challenge)
+    wait_for_status(challenge)  
     
     if challenge.verify_status == 'valid'
       # We can now request a certificate
@@ -62,7 +62,7 @@ task :letsencrypt_plugin => :setup_logger do
       if (!File.directory?(full_challenge_dir))
         Dir.mkdir(full_challenge_dir)
       end
-      File.open(File.join(full_challenge_dir, 'challenge'), 'w') { |file| file.write(challenge) }
+      File.open(File.join(full_challenge_dir, 'challenge'), 'w') { |file| file.write(challenge.file_content) }
     end
     sleep(2)
   end

--- a/lib/tasks/letsencrypt_plugin_tasks.rake
+++ b/lib/tasks/letsencrypt_plugin_tasks.rake
@@ -49,12 +49,20 @@ task :letsencrypt_plugin => :setup_logger do
   
   def store_challenge(challenge)
     Rails.logger.info("Storing challenge information...")
-    ch = LetsencryptPlugin::Challenge.first
-    if ch.nil?
-      ch = LetsencryptPlugin::Challenge.new
-      ch.save!(:response => challenge.file_content)
-    else
-      ch.update(:response => challenge.file_content)
+    if (CONFIG[:challenge_dir_name].empty?) # store in DB
+      ch = LetsencryptPlugin::Challenge.first
+      if ch.nil?
+        ch = LetsencryptPlugin::Challenge.new
+        ch.save!(:response => challenge.file_content)
+      else
+        ch.update(:response => challenge.file_content)
+      end
+    else # store in filesystem
+      full_challenge_dir = File.join(Rails.root, CONFIG[:challenge_dir_name]);
+      if (!File.Directory?(full_challenge_dir))
+        File.MkDir(full_challenge_dir)
+      end
+      File.open(File.join(full_challenge_dir, 'challenge'), 'w') { |file| file.write(challenge) }
     end
     sleep(2)
   end


### PR DESCRIPTION
Adds a new config argument, :challenge_dir_name, which is the folder name where the challenge is stored on the filesystem.  If it is set, the challenge is written to the filesystem there and served up from that location when requested.  This removes the need for a DB at all, and especially an ActiveRecord DB, which is good for those of us using MongoDB.
