### PR TITLE
database for challenge storage optional in AR projects

### DIFF
--- a/app/models/letsencrypt_plugin/challenge.rb
+++ b/app/models/letsencrypt_plugin/challenge.rb
@@ -1,7 +1,7 @@
 module LetsencryptPlugin
   # if the project doesn't use ActiveRecord, we assume the challenge will
   # be stored in the filesystem
-  if defined?(ActiveRecord::Base) == 'constant' && ActiveRecord::Base.class == Class
+  if CONFIG[:challenge_dir_name].blank? && defined?(ActiveRecord::Base) == 'constant' && ActiveRecord::Base.class == Class
     class Challenge < ActiveRecord::Base
     end
   else


### PR DESCRIPTION
allows for optional usage of filesystem even if the project should be ActiveRecord enabled

I did not want to utilize my database for the challenge in a project of mine.
Thanks for the plugin!