### PR TITLE
Namespaced config

### DIFF
--- a/app/controllers/letsencrypt_plugin/application_controller.rb
+++ b/app/controllers/letsencrypt_plugin/application_controller.rb
@@ -17,7 +17,7 @@ module LetsencryptPlugin
     end
 
     def challenge_response
-      @response = CONFIG[:challenge_dir_name] ? Challenge.new : Challenge.first
+      @response = LetsencryptPlugin.config.challenge_dir_name ? Challenge.new : Challenge.first
       challenge_failed('Challenge failed - Can not get response from database!') if @response.nil?
     end
 

--- a/app/models/letsencrypt_plugin/challenge.rb
+++ b/app/models/letsencrypt_plugin/challenge.rb
@@ -1,7 +1,7 @@
 module LetsencryptPlugin
   # if the project doesn't use ActiveRecord, we assume the challenge will
   # be stored in the filesystem
-  if CONFIG[:challenge_dir_name].blank? && defined?(ActiveRecord::Base) == 'constant' && ActiveRecord::Base.class == Class
+  if LetsencryptPlugin.config.challenge_dir_name.blank? && defined?(ActiveRecord::Base) == 'constant' && ActiveRecord::Base.class == Class
     class Challenge < ActiveRecord::Base
     end
   else
@@ -9,7 +9,7 @@ module LetsencryptPlugin
       attr_accessor :response
 
       def initialize
-        full_challenge_dir = File.join(Rails.root, CONFIG[:challenge_dir_name], 'challenge')
+        full_challenge_dir = File.join(Rails.root, LetsencryptPlugin.config.challenge_dir_name, 'challenge')
         @response = IO.read(full_challenge_dir)
       end
     end

--- a/config/initializers/letsencrypt_plugin.rb
+++ b/config/initializers/letsencrypt_plugin.rb
@@ -1,3 +1,3 @@
-CONFIG = YAML.load_file(Rails.root.join('config', 'letsencrypt_plugin.yml'))
-CONFIG.merge! CONFIG.fetch(Rails.env, {})
-CONFIG.symbolize_keys!
+config = YAML.load_file(Rails.root.join('config', 'letsencrypt_plugin.yml'))
+config.merge! config.fetch(Rails.env, {})
+LetsencryptPlugin.config = config

--- a/lib/letsencrypt_plugin.rb
+++ b/lib/letsencrypt_plugin.rb
@@ -7,6 +7,15 @@ require 'openssl'
 require 'acme/client'
 
 module LetsencryptPlugin
+  Config = Class.new(OpenStruct)
+  def self.config=(options)
+    @config = Config.new(options || {})
+  end
+
+  def self.config
+    @config || Config.new
+  end
+
   class CertGenerator
     attr_reader :options
     attr_writer :client

--- a/lib/tasks/letsencrypt_plugin_tasks.rake
+++ b/lib/tasks/letsencrypt_plugin_tasks.rake
@@ -10,6 +10,6 @@ end
 
 desc "Generates SSL certificate using Let's Encrypt service"
 task letsencrypt_plugin: :setup_logger do
-  cert_generator = LetsencryptPlugin::CertGenerator.new(CONFIG)
+  cert_generator = LetsencryptPlugin::CertGenerator.new(LetsencryptPlugin.config.to_h)
   cert_generator.generate_certificate
 end


### PR DESCRIPTION
Was using `CONFIG` global without namespacing which seems dangerous. This converts config things to a namespaced method on the top module as an Open Struct. This would also make it a bit simpler to redo the config, in the future, in favor of a fancier class that validates or has defaults. 