### PR TITLE
When swallowing exceptions, at least log them.

### DIFF
--- a/lib/letsencrypt_plugin.rb
+++ b/lib/letsencrypt_plugin.rb
@@ -90,7 +90,8 @@ module LetsencryptPlugin
       registration = client.register(contact: "mailto:#{@options[:email]}")
       registration.agree_terms
       Rails.logger.info('Registration succeed.')
-    rescue
+    rescue => e
+      Rails.logger.info("#{e.class} - #{e.message}")
       Rails.logger.info('Already registered.')
     end
 


### PR DESCRIPTION
It took me 3 hours to detect an underlying [3rd-party bug](https://github.com/unixcharles/acme-client/issues/68) because of this missing logging.

When Exceptions are swallowed during the registration phase, I only get a mysterious response some time later during the authorization process:

> Acme::Client::Error::Malformed: No registration exists matching provided key

When logging the Exception in the registration phase, which looked like this:

> Acme::Client::Error::Malformed - algorithm 'none' in JWS header not acceptable

I was able to google the issue and could solve it by adding `gem 'json-jwt', '1.5.2'` to my Gemfile as some people suggested.




