### PR TITLE
delay configuration when config file is symlinked later

### DIFF
--- a/config/initializers/letsencrypt_plugin.rb
+++ b/config/initializers/letsencrypt_plugin.rb
@@ -1,3 +1,7 @@
-config = YAML.load_file(Rails.root.join('config', 'letsencrypt_plugin.yml'))
-config.merge! config.fetch(Rails.env, {})
-LetsencryptPlugin.config = config
+begin
+  config = YAML.load_file(Rails.root.join('config', 'letsencrypt_plugin.yml'))
+  config.merge! config.fetch(Rails.env, {})
+  LetsencryptPlugin.config = config
+rescue Errno::ENOENT
+  LetsencryptPlugin.config_file = Rails.root.join('config', 'letsencrypt_plugin.yml')
+end

--- a/lib/letsencrypt_plugin.rb
+++ b/lib/letsencrypt_plugin.rb
@@ -12,6 +12,12 @@ module LetsencryptPlugin
     @config = Config.new(options || {})
   end
 
+  def self.config_file=(file_path)
+    options = YAML.load_file(file_path)
+    options.merge! options.fetch(Rails.env, {})
+    @config = Config.new(options || {})
+  end
+
   def self.config
     @config || Config.new
   end


### PR DESCRIPTION
One might want to store the letsencrypt_plugin.yml configuration file outside of Rails.root. This is because the code in Rails.root may be pulled from a public repo, e.g. github, and the configuration in letsencrypt_plugin.yml is site-specific, and does not apply to everyone who pulls the app from the repo... Since each site deploying from the repo will have its own letsencrypt_plugin.yml config file.

If you agree that this is desirable (you may not agree, but this is the situation in my application)...

This leads to a problem where the letsencrypt_plugin initializer tries to access the configuration file before it has been symlinked, during a capistrano deployment. To avoid this, the initializer should initialize only the path to the configuration file, and  LetsencryptPlugin receives as its configuration information just the file path, and not the contents of the configuration file, since those contents are not available when the initializer is run (b/c the symlink has not yet been configured).