### PR TITLE
Add support for erb in configuration

### DIFF
--- a/config/initializers/letsencrypt_plugin.rb
+++ b/config/initializers/letsencrypt_plugin.rb
@@ -1,7 +1,1 @@
-begin
-  config = YAML.load_file(Rails.root.join('config', 'letsencrypt_plugin.yml'))
-  config.merge! config.fetch(Rails.env, {})
-  LetsencryptPlugin.config = config
-rescue Errno::ENOENT
-  LetsencryptPlugin.config_file = Rails.root.join('config', 'letsencrypt_plugin.yml')
-end
+LetsencryptPlugin.config = LetsencryptPlugin::Configuration.load_file

--- a/lib/letsencrypt_plugin.rb
+++ b/lib/letsencrypt_plugin.rb
@@ -3,23 +3,18 @@ require 'letsencrypt_plugin/file_output'
 require 'letsencrypt_plugin/heroku_output'
 require 'letsencrypt_plugin/file_store'
 require 'letsencrypt_plugin/database_store'
+require 'letsencrypt_plugin/configuration'
 require 'openssl'
 require 'acme-client'
 
 module LetsencryptPlugin
-  Config = Class.new(OpenStruct)
-  def self.config=(options)
-    @config = Config.new(options || {})
-  end
-
-  def self.config_file=(file_path)
-    options = YAML.load_file(file_path)
-    options.merge! options.fetch(Rails.env, {})
-    @config = Config.new(options || {})
-  end
 
   def self.config
-    @config || Config.new
+    @config
+  end
+
+  def self.config=(config)
+    @config = config
   end
 
   class CertGenerator

--- a/lib/letsencrypt_plugin/configuration.rb
+++ b/lib/letsencrypt_plugin/configuration.rb
@@ -1,0 +1,33 @@
+module LetsencryptPlugin
+
+  Config = Class.new(OpenStruct) 
+
+  # This is a class whose responcsibility is to load the lets_encrypt configuration file
+  module Configuration
+    
+    def self.load_file(filename = Rails.root.join('config', 'letsencrypt_plugin.yml'))
+      config_data = parse_yaml_file(filename)
+      create_config(config_data)
+    end
+
+    private
+
+    def self.create_config(config_hash)
+      Config.new(config_hash.merge(config_hash.fetch(Rails.env, {})) || {})         
+    end
+
+    def self.read_file(filename)
+      File.read(filename)
+    end
+
+    def self.evaluate_file(filename)
+      ERB.new(read_file(filename)).result
+    end
+
+    def self.parse_yaml_file(filename)
+      YAML.load(evaluate_file(filename))
+    end
+
+  end
+  
+end

--- a/test/dummy/config/letsencrypt_plugin.yml
+++ b/test/dummy/config/letsencrypt_plugin.yml
@@ -1,7 +1,7 @@
 default: &default
   endpoint: 'https://acme-staging.api.letsencrypt.org/directory'  # test server
   email: 'your@email.address'
-  domain: 'example.com'
+  domain: '<%= ['example.com', 'www.example.com', 'another.example.com'].join(" ") %>'
   private_key: 'key/test-keyfile.pem'                   # in Rails.root
   output_cert_dir: 'certificates'                       # in Rails.root
   private_key_in_db: true

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.

--- a/test/lib/letsencrypt_plugin/configuration_test.rb
+++ b/test/lib/letsencrypt_plugin/configuration_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class LetsencryptPlugin::ConfigurationTest < ActiveSupport::TestCase
+  
+  test 'reads multiple domains from test config' do
+    config_file_path = Rails.root.join('config', 'letsencrypt_plugin.yml')
+    config = LetsencryptPlugin::Configuration.load_file(config_file_path)
+    domains = config.domain.split(' ')
+    assert_kind_of Array, domains
+    assert_operator domains.length, :>, 0
+  end
+
+end


### PR DESCRIPTION
> Notes: I am very happy to add documentation for this once it is merged.

This pull request contains:

* ERB evaluation for configuration files
* Tests to confirm that this works

Use case:

We have a dynamic set of domains and subdomains, available at run time, that we need to support TLS on.

Please feel free to ask any questions, request changes or make suggestions. I hope that this functionality is sufficiently valuable to be merged in so that I don't need to depend on my own fork of this anymore.