### PR TITLE
Lazy load the configuration

### DIFF
--- a/config/initializers/letsencrypt_plugin.rb
+++ b/config/initializers/letsencrypt_plugin.rb
@@ -1,1 +1,0 @@
-LetsencryptPlugin.config = LetsencryptPlugin::Configuration.load_file

--- a/lib/letsencrypt_plugin.rb
+++ b/lib/letsencrypt_plugin.rb
@@ -10,7 +10,8 @@ require 'acme-client'
 module LetsencryptPlugin
 
   def self.config
-    @config
+    # load files on demand
+    @config ||= Configuration.load_file
   end
 
   def self.config=(config)


### PR DESCRIPTION
This allows rails models to be loaded from within the config file at
runtime, after rails has been initialized (migrated etc)

Really sorry if this is spamy, I totally should have checked this before submitting the previous pull request. Thanks (again) for being so fast last time.