### PR TITLE
Update quotes of dynamic domains

### DIFF
--- a/test/dummy/config/letsencrypt_plugin.yml
+++ b/test/dummy/config/letsencrypt_plugin.yml
@@ -1,7 +1,7 @@
 default: &default
   endpoint: 'https://acme-staging.api.letsencrypt.org/directory'  # test server
   email: 'your@email.address'
-  domain: "<%= ['example.com', 'www.example.com', 'another.example.com'].join(" ") %>"
+  domain: "<%= ['example.com', 'www.example.com', 'another.example.com'].join(' ') %>"
   private_key: 'key/test-keyfile.pem'                   # in Rails.root
   output_cert_dir: 'certificates'                       # in Rails.root
   private_key_in_db: true

--- a/test/dummy/config/letsencrypt_plugin.yml
+++ b/test/dummy/config/letsencrypt_plugin.yml
@@ -1,7 +1,7 @@
 default: &default
   endpoint: 'https://acme-staging.api.letsencrypt.org/directory'  # test server
   email: 'your@email.address'
-  domain: '<%= ['example.com', 'www.example.com', 'another.example.com'].join(" ") %>'
+  domain: "<%= ['example.com', 'www.example.com', 'another.example.com'].join(" ") %>"
   private_key: 'key/test-keyfile.pem'                   # in Rails.root
   output_cert_dir: 'certificates'                       # in Rails.root
   private_key_in_db: true


### PR DESCRIPTION
Lots of people are experiencing errors from there not being double quotes around the erb. This should help reduce the number of errors people experience.