### PR TITLE
Adding @cert Acessor And Rewriting file If Exists

### DIFF
--- a/lib/letsencrypt_plugin.rb
+++ b/lib/letsencrypt_plugin.rb
@@ -145,7 +145,6 @@ module LetsencryptPlugin
     def save_certificate(certificate)
       begin
         return HerokuOutput.new(common_domain_name, certificate).output unless ENV['DYNO'].nil?
-        @cert = certificate
         output_dir = File.join(Rails.root, @options[:output_cert_dir])
         return FileOutput.new(common_domain_name, certificate, output_dir).output if File.directory?(output_dir)
         Rails.logger.error("Output directory: '#{output_dir}' does not exist!")

--- a/lib/letsencrypt_plugin/file_output.rb
+++ b/lib/letsencrypt_plugin/file_output.rb
@@ -8,7 +8,7 @@ module LetsencryptPlugin
     end
 
     def output_cert(cert_type, cert_content)
-      File.write(File.join(@output_dir, "#{@domain}-#{cert_type}"), cert_content)
+      File.open(File.join(@output_dir, "#{@domain}-#{cert_type}").to_s, 'w'){ |f| f.write cert_content }
     end
 
     def display_info

--- a/lib/letsencrypt_plugin/file_output.rb
+++ b/lib/letsencrypt_plugin/file_output.rb
@@ -8,7 +8,7 @@ module LetsencryptPlugin
     end
 
     def output_cert(cert_type, cert_content)
-      File.open(File.join(@output_dir, "#{@domain}-#{cert_type}").to_s, 'w'){ |f| f.write cert_content }
+      File.write(File.join(@output_dir, "#{@domain}-#{cert_type}"), cert_content)
     end
 
     def display_info


### PR DESCRIPTION
Users who do not use the provided task, but instead use the class that the task uses may want to have access to the cert object after its requested. 