### PR TITLE
new config key 'cert_name'

### DIFF
--- a/lib/letsencrypt_plugin.rb
+++ b/lib/letsencrypt_plugin.rb
@@ -96,7 +96,7 @@ module LetsencryptPlugin
     end
 
     def common_domain_name
-      @domain ||= @options[:domain].split(' ').first.to_s
+      @domain ||= @options[:cert_name] || @options[:domain].split(' ').first.to_s
     end
 
     def authorize(domain = common_domain_name)

--- a/test/dummy/config/letsencrypt_plugin.yml
+++ b/test/dummy/config/letsencrypt_plugin.yml
@@ -7,10 +7,13 @@ default: &default
   private_key_in_db: true
 
 production:
+  cert_name: 'production'
   <<: *default
 
 development:
+  cert_name: 'development'
   <<: *default
 
 test:
+  cert_name: 'test'
   <<: *default


### PR DESCRIPTION
If this key isn't set, the first entry in 'domain' is used a the key name, as usual.
If it is set, its value will be used for the key names.
